### PR TITLE
Fix Scalecube provider 'entries' method to response according to API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capsulajs/capsulajs-configuration-service",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Capsula-JS Configuration Service",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/api/ConfigurationService.ts
+++ b/src/api/ConfigurationService.ts
@@ -39,10 +39,10 @@ export interface ConfigurationService<T = any> {
    * Gets the value of the specified key
    * @return promise with the key's values
    * */
-  fetch(request: FetchRequest): Promise<FetchResponse>;
+  fetch(request: FetchRequest): Promise<FetchResponse<T>>;
   /**
    * Sets the value of the specified key
    * @return an empty promise
    * */
-  save(request: SaveRequest): Promise<SaveResponse>;
-};
+  save(request: SaveRequest<T>): Promise<SaveResponse>;
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,6 +1,7 @@
 export { ConfigurationService } from './ConfigurationService';
 export { Token } from './Token';
 export { Repository } from './Repository';
+export {Entity} from './Entity';
 export {
   CreateRepositoryRequest,
   CreateRepositoryResponse,

--- a/src/provider/Scalecube/ConfigurationServiceScalecube.ts
+++ b/src/provider/Scalecube/ConfigurationServiceScalecube.ts
@@ -7,6 +7,7 @@ import {
   DeleteResponse,
   EntriesRequest,
   EntriesResponse,
+  Entity,
   FetchRequest,
   FetchResponse,
   SaveRequest,
@@ -51,7 +52,8 @@ export class ConfigurationServiceScalecube<T=any> implements ConfigurationServic
       return Promise.reject(new Error(messages.repositoryNotProvided));
     }
 
-    return this.dispatcher.dispatch(`${endpoint}/entries`, this.prepRequest(request));
+    return this.dispatcher.dispatch<any, Entity<T>[]>(`${endpoint}/entries`, this.prepRequest(request))
+      .then(entries => ({entries}));
   }
 
   fetch(request: FetchRequest): Promise<FetchResponse<T>> {


### PR DESCRIPTION
Issue https://github.com/capsulajs/configuration-service/issues/29

Release notes:
Use the correct response from Scalecube provider.