### PR TITLE
Add cache support for httpFile Provider

### DIFF
--- a/src/provider/HttpFile/ConfigurationServiceHttpFile.ts
+++ b/src/provider/HttpFile/ConfigurationServiceHttpFile.ts
@@ -22,7 +22,7 @@ import {
   getRepositoryKeyNotFoundErrorMessage
 } from '../../utils';
 
-interface ConfigurationServiceHttpFileRequest {
+interface Options {
   token: string,
   disableCache?: boolean
 }
@@ -31,13 +31,20 @@ export class ConfigurationServiceHttpFile implements ConfigurationService {
   private token: string = '';
   private disableCache?: boolean;
 
-  constructor(request: string | ConfigurationServiceHttpFileRequest) {
+  /**
+    ConfigurationServiceHttpFile constructor
+    A provider for 'http file' method of fetching configuration
+    @param {request} an object of 'Options' type, which includes (token: string, disableCache?: boolean)
+    Note: passing 'string' it's deprecated, please provide an object
+  */
+  constructor(request: string | Options) {
+    // 'typeof request === string' is for backward compatibility and it's deprecated
     if(typeof request === 'string') {
       this.token = request;
     }
     else if(typeof request === 'object') {
       this.token = request.token;
-      this.disableCache = request.disableCache;
+      this.disableCache = request.disableCache || false;
     }
 
     if (!this.token) {

--- a/src/provider/HttpFile/ConfigurationServiceHttpFile.ts
+++ b/src/provider/HttpFile/ConfigurationServiceHttpFile.ts
@@ -24,12 +24,12 @@ import {
 
 interface ConfigurationServiceHttpFileRequest {
   token: string,
-  cache?: boolean
+  disableCache?: boolean
 }
 
 export class ConfigurationServiceHttpFile implements ConfigurationService {
   private token: string = '';
-  private cache?: boolean;
+  private disableCache?: boolean;
 
   constructor(request: string | ConfigurationServiceHttpFileRequest) {
     if(typeof request === 'string') {
@@ -37,7 +37,7 @@ export class ConfigurationServiceHttpFile implements ConfigurationService {
     }
     else if(typeof(request) === 'object') {
       this.token = request.token;
-      this.cache = request.cache;
+      this.disableCache = request.disableCache;
     }
 
     if (!this.token) {
@@ -47,7 +47,7 @@ export class ConfigurationServiceHttpFile implements ConfigurationService {
 
   private getRepository(repository: string): Promise<Repository> {
     return new Promise((resolve, reject) => {
-      fetchFile(this.token, repository, this.cache)
+      fetchFile(this.token, repository, this.disableCache)
         .then((repo: Repository) => {
           Object.keys(repo).length ? resolve(repo) : reject(new Error(getRepositoryNotFoundErrorMessage(repository)));
         })

--- a/src/provider/HttpFile/ConfigurationServiceHttpFile.ts
+++ b/src/provider/HttpFile/ConfigurationServiceHttpFile.ts
@@ -35,7 +35,7 @@ export class ConfigurationServiceHttpFile implements ConfigurationService {
     if(typeof request === 'string') {
       this.token = request;
     }
-    else if(typeof(request) === 'object') {
+    else if(typeof request === 'object') {
       this.token = request.token;
       this.disableCache = request.disableCache;
     }

--- a/src/provider/HttpFile/ConfigurationServiceHttpFile.ts
+++ b/src/provider/HttpFile/ConfigurationServiceHttpFile.ts
@@ -22,8 +22,24 @@ import {
   getRepositoryKeyNotFoundErrorMessage
 } from '../../utils';
 
+interface ConfigurationServiceHttpFileRequest {
+  token: string,
+  cache?: boolean
+}
+
 export class ConfigurationServiceHttpFile implements ConfigurationService {
-  constructor(private token: string) {
+  private token: string = '';
+  private cache?: boolean;
+
+  constructor(request: string | ConfigurationServiceHttpFileRequest) {
+    if(typeof request === 'string') {
+      this.token = request;
+    }
+    else if(typeof(request) === 'object') {
+      this.token = request.token;
+      this.cache = request.cache;
+    }
+
     if (!this.token) {
       throw new Error(messages.tokenNotProvided);
     }
@@ -31,7 +47,7 @@ export class ConfigurationServiceHttpFile implements ConfigurationService {
 
   private getRepository(repository: string): Promise<Repository> {
     return new Promise((resolve, reject) => {
-      fetchFile(this.token, repository)
+      fetchFile(this.token, repository, this.cache)
         .then((repo: Repository) => {
           Object.keys(repo).length ? resolve(repo) : reject(new Error(getRepositoryNotFoundErrorMessage(repository)));
         })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,7 +37,7 @@ export const messages = {
 };
 
 export const fetchFile = (token: string, fileName: string, disableCache?: boolean) => {
-  const timeStamp = disableCache ? `?=${new Date().getTime()}`: '';
+  const timeStamp = disableCache ? `?=${Date.now()}`: '';
   return fetch(`${token}/${fileName}.json${timeStamp}`).then((response) => response.json())};
 
 export const formatRepositoryToEntries = (repository: Repository) => Object.keys(repository)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,8 +36,9 @@ export const messages = {
   getProviderInvalidRequest: `GetProvider request is not valid`,
 };
 
-export const fetchFile = (token: string, fileName: string) => fetch(`${token}/${fileName}.json`)
-  .then((response) => response.json());
+export const fetchFile = (token: string, fileName: string, cache?: boolean) => {
+  const timeStamp = cache ? `?=${new Date().getTime()}`: '';
+  return fetch(`${token}/${fileName}.json${timeStamp}`).then((response) => response.json())};
 
 export const formatRepositoryToEntries = (repository: Repository) => Object.keys(repository)
   .map(key => ({ key, value: repository[key] }));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,8 +36,8 @@ export const messages = {
   getProviderInvalidRequest: `GetProvider request is not valid`,
 };
 
-export const fetchFile = (token: string, fileName: string, cache?: boolean) => {
-  const timeStamp = cache ? `?=${new Date().getTime()}`: '';
+export const fetchFile = (token: string, fileName: string, disableCache?: boolean) => {
+  const timeStamp = disableCache ? `?=${new Date().getTime()}`: '';
   return fetch(`${token}/${fileName}.json${timeStamp}`).then((response) => response.json())};
 
 export const formatRepositoryToEntries = (repository: Repository) => Object.keys(repository)

--- a/tests/ConfigurationServiceHttpFile/data.test.ts
+++ b/tests/ConfigurationServiceHttpFile/data.test.ts
@@ -7,25 +7,43 @@ const key = 'artist';
 const value = 'Oxxy';
 const surprise = 'This is all Matrix';
 const configurationData = {
-  [key]: value,
-  Surprise: surprise
+    [key]: value,
+    Surprise: surprise
 };
 
-const configService = new ConfigurationServiceHttpFile(token);
-
-describe('Test suite for the ConfigurationServiceHttpFile', () => {
-  it('entries() should return all values and keys', async () => {
-    expect.assertions(1);
-    mockFetchFile({ type: 'resolve', content: configurationData });
-    return expect(configService.entries({ repository })).resolves.toEqual({
-      entries: [{ key, value }, { key: 'Surprise', value: surprise }]
+describe('Test suite for the ConfigurationServiceHttpFile(token)', () => {
+    it('entries() should return all values and keys', async () => {
+        expect.assertions(1);
+        mockFetchFile({ type: 'resolve', content: configurationData });
+        const configService = new ConfigurationServiceHttpFile(token);
+        return expect(configService.entries({ repository })).resolves.toEqual({
+            entries: [{ key, value }, { key: 'Surprise', value: surprise }]
+        });
     });
-  });
 
-  it('fetch() should return value by key', async () => {
-    expect.assertions(1);
-    mockFetchFile({ type: 'resolve', content: configurationData });
-    return expect(configService.fetch({ repository, key })).resolves.toEqual({ key, value });
-  });
-
+    it('fetch() should return value by key', async () => {
+        expect.assertions(1);
+        const configService = new ConfigurationServiceHttpFile(token);
+        mockFetchFile({ type: 'resolve', content: configurationData });
+        return expect(configService.fetch({ repository, key })).resolves.toEqual({ key, value });
+    });
 });
+
+describe('Test suite for the ConfigurationServiceHttpFile( {token: token, disableCache: true/false} )', () => {
+    it('entries() should return all values and keys', async () => {
+        expect.assertions(1);
+        mockFetchFile({ type: 'resolve', content: configurationData });
+        const configService = new ConfigurationServiceHttpFile({ token, disableCache: true });
+        return expect(configService.entries({ repository })).resolves.toEqual({
+            entries: [{ key, value }, { key: 'Surprise', value: surprise }]
+        });
+    });
+
+    it('fetch() should return value by key, disableCache = false', async () => {
+        expect.assertions(1);
+        const configService = new ConfigurationServiceHttpFile({ token, disableCache: false });
+        mockFetchFile({ type: 'resolve', content: configurationData });
+        return expect(configService.fetch({ repository, key })).resolves.toEqual({ key, value });
+    });
+});
+

--- a/tests/ConfigurationServiceHttpFile/errors.test.ts
+++ b/tests/ConfigurationServiceHttpFile/errors.test.ts
@@ -1,4 +1,3 @@
-import { ConfigurationServiceHttp } from 'provider/HttpProvider';
 import { messages } from '../../src';
 import { runTestsRejectedError } from '../utils';
 import { ConfigurationServiceHttpFile } from 'provider/HttpFile';
@@ -10,8 +9,8 @@ const key = 'artist';
 const value = 'Oxxy';
 const surprise = 'This is all Matrix';
 const configurationData = {
-  [key]: value,
-  Surprise: surprise
+    [key]: value,
+    Surprise: surprise
 };
 
 const notFoundRepo = 'notFoundRepo';
@@ -21,52 +20,57 @@ const configService = new ConfigurationServiceHttpFile(token);
 
 describe('Test suite for the ConfigurationServiceHttpFile', () => {
 
-  it('New instance of service should throw \'dispatcherNotProvided\' error', () => {
-    expect.assertions(1);
-    // @ts-ignore
-    return expect(() => new ConfigurationServiceHttpFile()).toThrow(new Error(messages.tokenNotProvided));
-  });
+    it('New instance of service should throw \'tokenNotProvided\' error', async () => {
+        expect.assertions(6);
+        // @ts-ignore
+        await expect(() => new ConfigurationServiceHttpFile({})).toThrow(new Error(messages.tokenNotProvided));
+        await expect(() => new ConfigurationServiceHttpFile({ disableCache: true })).toThrow(new Error(messages.tokenNotProvided));
+        await expect(() => new ConfigurationServiceHttpFile({ dummyField: true })).toThrow(new Error(messages.tokenNotProvided));
+        await expect(() => new ConfigurationServiceHttpFile({ token: '' })).toThrow(new Error(messages.tokenNotProvided));
+        await expect(() => new ConfigurationServiceHttpFile({ token: undefined })).toThrow(new Error(messages.tokenNotProvided));
+        return expect(() => new ConfigurationServiceHttpFile()).toThrow(new Error(messages.tokenNotProvided));
+    });
 
-  it('New instance should return \'repositoryNotProvided\' error', (done) => {
-    runTestsRejectedError(expect, done)(
-      configService,
-      ['entries', 'fetch'],
-      {},
-      new Error(messages.repositoryNotProvided)
-    );
-  });
+    it('New instance should return \'repositoryNotProvided\' error', (done) => {
+        runTestsRejectedError(expect, done)(
+            configService,
+            ['entries', 'fetch'],
+            {},
+            new Error(messages.repositoryNotProvided)
+        );
+    });
 
-  it('Call fetch(), entries() with unexisting repository should return \'repository not found\' error', (done) => {
-    runTestsRejectedError(expect, done)(
-      configService,
-      ['entries', 'fetch'],
-      { repository: notFoundRepo, key },
-      new Error(`Configuration repository ${notFoundRepo} not found`),
-      () => {
-        mockFetchFile({ type: 'reject', content: 'file not found' })
-      }
-    );
-  });
+    it('Call fetch(), entries() with unexisting repository should return \'repository not found\' error', (done) => {
+        runTestsRejectedError(expect, done)(
+            configService,
+            ['entries', 'fetch'],
+            { repository: notFoundRepo, key },
+            new Error(`Configuration repository ${notFoundRepo} not found`),
+            () => {
+                mockFetchFile({ type: 'reject', content: 'file not found' })
+            }
+        );
+    });
 
-  it('Call fetch() without providing key should return \'repositoryKeyNotProvided\' error', (done) => {
-    runTestsRejectedError(expect, done)(
-      configService,
-      ['fetch'],
-      { repository },
-      new Error(messages.repositoryKeyNotProvided)
-    );
-  });
+    it('Call fetch() without providing key should return \'repositoryKeyNotProvided\' error', (done) => {
+        runTestsRejectedError(expect, done)(
+            configService,
+            ['fetch'],
+            { repository },
+            new Error(messages.repositoryKeyNotProvided)
+        );
+    });
 
-  it('Call fetch()  with unexisting key should return \'repository key not found\' error', (done) => {
-    runTestsRejectedError(expect, done)(
-      configService,
-      ['fetch'],
-      { repository, key: notFoundKey },
-      new Error(`Configuration repository key ${notFoundKey} not found`),
-      () => {
-        mockFetchFile({ type: 'resolve', content: configurationData })
-      }
-    );
-  });
+    it('Call fetch()  with unexisting key should return \'repository key not found\' error', (done) => {
+        runTestsRejectedError(expect, done)(
+            configService,
+            ['fetch'],
+            { repository, key: notFoundKey },
+            new Error(`Configuration repository key ${notFoundKey} not found`),
+            () => {
+                mockFetchFile({ type: 'resolve', content: configurationData })
+            }
+        );
+    });
 
 });


### PR DESCRIPTION
Additional param was added to httpFile Constructor - disableCache, which by default is false and it should be backward compatible. Its main purpose is to disable browser cache by adding a timestamp to url and request each time a non-cached version of configuration.

logic from constructor was requested by @stephanebenayoun , because all constructors has to have only one parameter in constructor.