### PR TITLE
[Feature] CreateEntry and UpdateEntry methods

### DIFF
--- a/src/api/ConfigurationService.ts
+++ b/src/api/ConfigurationService.ts
@@ -41,8 +41,32 @@ export interface ConfigurationService<T = any> {
    * */
   fetch(request: FetchRequest): Promise<FetchResponse<T>>;
   /**
+   /**
    * Sets the value of the specified key
+   * Deprecated method
    * @return an empty promise
    * */
   save(request: SaveRequest<T>): Promise<SaveResponse>;
+  /**
+   * Creates a new entry in ConfigurationService
+   * @return a promise, that is resolved when a new entry has been successfully created
+   * Rejected in case of:
+   * Code|Description
+   * -----|-----
+   * ERR_ALREADY_EXIST|The entry with a provided key already exists|
+   * ERR_INVALID_REQUEST|Request is invalid|
+   * ERR_NETWORK_ERROR|Network error while providing the operation|
+   * */
+  createEntry(request: SaveRequest<T>): Promise<SaveResponse>;
+  /**
+   * Updates an existing entry in ConfigurationService
+   * @return a promise, that is resolved when a new entry has been successfully updated
+   * Rejected in case of:
+   * Code|Description
+   * -----|-----
+   * ERR_NOT_EXIST|The entry with a provided key hasn't been created yet|
+   * ERR_INVALID_REQUEST|Request is invalid|
+   * ERR_NETWORK_ERROR|Network error while providing the operation|
+   * */
+  updateEntry(request: SaveRequest<T>): Promise<SaveResponse>;
 }

--- a/src/provider/FileProvider/ConfigurationServiceFile.ts
+++ b/src/provider/FileProvider/ConfigurationServiceFile.ts
@@ -69,4 +69,12 @@ export class ConfigurationServiceFile<T=any> implements ConfigurationService<T> 
   save(request: SaveRequest): Promise<SaveResponse> {
     return Promise.reject(new Error(messages.notImplemented));
   }
+
+  createEntry(request: SaveRequest) {
+    return Promise.reject(new Error(messages.notImplemented));
+  }
+
+  updateEntry(request: SaveRequest) {
+    return Promise.reject(new Error(messages.notImplemented));
+  }
 }

--- a/src/provider/HttpFile/ConfigurationServiceHttpFile.ts
+++ b/src/provider/HttpFile/ConfigurationServiceHttpFile.ts
@@ -103,4 +103,12 @@ export class ConfigurationServiceHttpFile implements ConfigurationService {
   save(request: SaveRequest): Promise<SaveResponse> {
     return Promise.reject(new Error(messages.notImplemented));
   }
+
+  createEntry(request: SaveRequest) {
+    return Promise.reject(new Error(messages.notImplemented));
+  }
+
+  updateEntry(request: SaveRequest) {
+    return Promise.reject(new Error(messages.notImplemented));
+  }
 }

--- a/src/provider/HttpProvider/ConfigurationServiceHttp.ts
+++ b/src/provider/HttpProvider/ConfigurationServiceHttp.ts
@@ -79,4 +79,12 @@ export class ConfigurationServiceHttp implements ConfigurationService {
   save(request: SaveRequest): Promise<SaveResponse> {
     return Promise.reject(new Error(messages.notImplemented));
   }
+
+  createEntry(request: SaveRequest) {
+    return Promise.reject(new Error(messages.notImplemented));
+  }
+
+  updateEntry(request: SaveRequest) {
+    return Promise.reject(new Error(messages.notImplemented));
+  }
 }

--- a/src/provider/LocalStorage/ConfigurationServiceLocalStorage.ts
+++ b/src/provider/LocalStorage/ConfigurationServiceLocalStorage.ts
@@ -19,16 +19,16 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
       throw new Error(messages.tokenNotProvided);
     }
   }
-  
+
   private getRepository(repository: string) {
     const rawString = localStorage.getItem(`${this.token}.${repository}`);
-    
+
     if (!rawString) {
       return Promise.reject(
         new Error(`Configuration repository ${repository} not found`)
       );
     }
-  
+
     try {
       return Promise.resolve(JSON.parse(rawString));
     } catch (error) {
@@ -40,7 +40,7 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
     if (repositoryRequestValidator(request)) {
       return Promise.reject(new Error(messages.repositoryNotProvided));
     }
-    
+
     return new Promise((resolve, reject) => {
       this.getRepository(request.repository).then(() => {
         reject(new Error(messages.repositoryAlreadyExists));
@@ -55,30 +55,30 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
     if (repositoryRequestValidator(request)) {
       return Promise.reject(new Error(messages.repositoryNotProvided));
     }
-    
+
     return new Promise((resolve, reject) => {
       this.getRepository(request.repository).then((repository) => {
         if (request.key) {
           if (!repository.hasOwnProperty(request.key)) {
             reject(new Error(`Configuration repository key ${request.key} not found`));
           }
-  
+
           const { [request.key]: value, ...rest } = repository;
           localStorage.setItem(`${this.token}.${request.repository}`, JSON.stringify(rest));
         } else {
           localStorage.removeItem(`${this.token}.${request.repository}`);
         }
-        
+
         resolve({});
       }).catch(reject);
     });
   }
-  
+
   entries(request: EntriesRequest): Promise<EntriesResponse<T>> {
     if (repositoryRequestValidator(request)) {
       return Promise.reject(new Error(messages.repositoryNotProvided));
     }
-    
+
     return this.getRepository(request.repository).then(repository => ({
       entries: Object.keys(repository).map(key => ({ key, value: repository[key] }))
     }));
@@ -88,11 +88,11 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
     if (repositoryRequestValidator(request)) {
       return Promise.reject(new Error(messages.repositoryNotProvided));
     }
-    
+
     if (repositoryKeyRequestValidator(request)) {
       return Promise.reject(new Error(messages.repositoryKeyNotProvided));
     }
-    
+
     return new Promise((resolve, reject) => {
       this.getRepository(request.repository).then(repository =>
         Object.keys(repository).indexOf(request.key) >= 0
@@ -106,20 +106,28 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
     if (repositoryRequestValidator(request)) {
       return Promise.reject(new Error(messages.repositoryNotProvided));
     }
-  
+
     if (repositoryKeyRequestValidator(request)) {
       return Promise.reject(new Error(messages.repositoryKeyNotProvided));
     }
-    
+
     return new Promise((resolve, reject) => {
       this.getRepository(request.repository).then((repository) => {
         localStorage.setItem(`${this.token}.${request.repository}`, JSON.stringify({
           ...repository,
           [request.key]: request.value
         }));
-        
+
         resolve({});
       }).catch(reject);
     });
+  }
+
+  createEntry(request: SaveRequest) {
+    return Promise.reject(new Error(messages.notImplemented));
+  }
+
+  updateEntry(request: SaveRequest) {
+    return Promise.reject(new Error(messages.notImplemented));
   }
 }

--- a/src/provider/Scalecube/ConfigurationServiceScalecube.ts
+++ b/src/provider/Scalecube/ConfigurationServiceScalecube.ts
@@ -14,7 +14,7 @@ import {
   SaveResponse,
 } from '../../api';
 import {messages, repositoryKeyRequestValidator, repositoryRequestValidator} from '../../utils';
-import { isNonEmptyString, isObject } from '../../validators';
+import { isNonEmptyString, isObject, validateSaveEntryRequest } from '../../validators';
 
 const endpoint = '/configuration';
 
@@ -98,14 +98,10 @@ export class ConfigurationServiceScalecube<T = any> implements ConfigurationServ
   }
 
   private changeEntry = (request: SaveRequest<T>, mode: 'update' | 'create') => {
-    if (!isObject(request)) {
-      return Promise.reject(new Error(messages.invalidRequest));
-    }
-    if (!isNonEmptyString(request.key)) {
-      return Promise.reject(new Error(messages.invalidKey));
-    }
-    if (!isNonEmptyString(request.repository)) {
-      return Promise.reject(new Error(messages.invalidRepository));
+    try {
+      validateSaveEntryRequest(request);
+    } catch (error) {
+      return Promise.reject(error);
     }
 
     return this.dispatcher.dispatch(`${endpoint}/${mode}Entry`, this.prepRequest(request))

--- a/src/provider/Scalecube/ConfigurationServiceScalecube.ts
+++ b/src/provider/Scalecube/ConfigurationServiceScalecube.ts
@@ -14,6 +14,7 @@ import {
   SaveResponse,
 } from '../../api';
 import {messages, repositoryKeyRequestValidator, repositoryRequestValidator} from '../../utils';
+import { isNonEmptyString, isObject } from '../../validators';
 
 const endpoint = '/configuration';
 
@@ -87,6 +88,29 @@ export class ConfigurationServiceScalecube<T = any> implements ConfigurationServ
       }
     }
   }
+
+  public createEntry(request: SaveRequest<T>) {
+    return this.changeEntry(request, 'create');
+  }
+
+  public updateEntry(request: SaveRequest<T>) {
+    return this.changeEntry(request, 'update');
+  }
+
+  private changeEntry = (request: SaveRequest<T>, mode: 'update' | 'create') => {
+    if (!isObject(request)) {
+      return Promise.reject(new Error(messages.invalidRequest));
+    }
+    if (!isNonEmptyString(request.key)) {
+      return Promise.reject(new Error(messages.invalidKey));
+    }
+    if (!isNonEmptyString(request.repository)) {
+      return Promise.reject(new Error(messages.invalidRepository));
+    }
+
+    return this.dispatcher.dispatch(`${endpoint}/${mode}Entry`, this.prepRequest(request))
+      .then(() => ({}));
+  };
 
   private prepRequest(request: any): any {
     return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,6 +38,9 @@ export const messages = {
   invalidRequest: 'Request is invalid - it should be a valid object',
   invalidRepository: 'Repository is invalid - it should be a non-empty string',
   invalidKey: 'Key is invalid - it should be a non-empty string',
+  entryAlreadyExist: (key: string) => `The entry for the key "${key}" already exists`,
+  entryDoesNotExist: (key: string) => `The entry for the key "${key}" has not been created yet`,
+  repositoryDoesNotExist: (repository: string) => `Configuration repository ${repository} not found`,
 };
 
 export const fetchFile = (token: string, fileName: string, disableCache?: boolean) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,6 +35,9 @@ export const messages = {
   repositoryAlreadyExists: 'Configuration repository already exists',
   configProviderDoesNotExist: `ConfigProvider does not exist. One of these values is available: ${Object.keys(configurationTypes).join(', ')}`,
   getProviderInvalidRequest: `GetProvider request is not valid`,
+  invalidRequest: 'Request is invalid - it should be a valid object',
+  invalidRepository: 'Repository is invalid - it should be a non-empty string',
+  invalidKey: 'Key is invalid - it should be a non-empty string',
 };
 
 export const fetchFile = (token: string, fileName: string, disableCache?: boolean) => {

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,3 +1,3 @@
-export const isObject = (val: any) => !!val && typeof val === 'object';
+export const isObject = (val: any) => !!val && typeof val === 'object' && typeof val.map !== 'function';
 
 export const isNonEmptyString = (val: any) => typeof val === 'string' && !!val.trim();

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,3 +1,17 @@
+import { messages } from './utils';
+
 export const isObject = (val: any) => !!val && typeof val === 'object' && typeof val.map !== 'function';
 
 export const isNonEmptyString = (val: any) => typeof val === 'string' && !!val.trim();
+
+export const validateSaveEntryRequest = (request: any) => {
+  if (!isObject(request)) {
+    throw new Error(messages.invalidRequest);
+  }
+  if (!isNonEmptyString(request.key)) {
+    throw new Error(messages.invalidKey);
+  }
+  if (!isNonEmptyString(request.repository)) {
+    throw new Error(messages.invalidRepository);
+  }
+};

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,0 +1,3 @@
+export const isObject = (val: any) => !!val && typeof val === 'object';
+
+export const isNonEmptyString = (val: any) => typeof val === 'string' && !!val.trim();

--- a/tests/ConfigurationServiceLocalStorage/data.test.ts
+++ b/tests/ConfigurationServiceLocalStorage/data.test.ts
@@ -1,4 +1,3 @@
-import { ConfigurationService } from 'api/ConfigurationService';
 import { ConfigurationServiceLocalStorage } from 'provider/LocalStorage';
 
 const token = 'token';
@@ -9,13 +8,13 @@ const configService = new ConfigurationServiceLocalStorage(token);
 
 describe('Test suite for the ConfigurationServiceLocalStorage', () => {
   beforeEach(localStorage.clear);
-  
+
   it('createRepository() should create configuration repository', async () => {
     expect.assertions(2);
     expect(await configService.createRepository({ repository })).toEqual({ repository });
     expect(await configService.entries({ repository })).toEqual({ entries: [] });
   });
-  
+
   it('delete() should return empty object and delete configuration repository key', async () => {
     expect.assertions(5);
     expect(await configService.createRepository({ repository })).toEqual({ repository });
@@ -24,7 +23,7 @@ describe('Test suite for the ConfigurationServiceLocalStorage', () => {
     expect(await configService.delete({ repository, key })).toEqual({});
     expect(await configService.entries({ repository })).toEqual({ entries: [] });
   });
-  
+
   it('entries() should return all values and keys', async () => {
     expect.assertions(4);
     expect(await configService.createRepository({ repository })).toEqual({ repository });
@@ -36,21 +35,21 @@ describe('Test suite for the ConfigurationServiceLocalStorage', () => {
       entries: [{ key, value }, { key: 'Surprise', value: 'I have a balloon' }]
     });
   });
-  
+
   it('fetch() should return value by key', async () => {
     expect.assertions(3);
     expect(await configService.createRepository({ repository })).toEqual({ repository });
     expect(await configService.save({ repository, key, value })).toEqual({});
     expect(await configService.fetch({ repository, key })).toEqual({ key, value });
   });
-  
+
   it('save() should persist value by key', async () => {
     expect.assertions(3);
     expect(await configService.createRepository({ repository })).toEqual({ repository });
     expect(await configService.save({ repository, key, value })).toEqual({});
     expect(await configService.entries({ repository })).toEqual({ entries: [{ key, value }] });
   });
-  
+
   it('save() should persist new value by the same key', async () => {
     expect.assertions(5);
     expect(await configService.createRepository({ repository })).toEqual({ repository });
@@ -59,5 +58,21 @@ describe('Test suite for the ConfigurationServiceLocalStorage', () => {
     expect(await configService.save({ repository, key, value: 'Goodbye' })).toEqual({});
     expect(await configService.entries({ repository })).toEqual({ entries: [{ key, value: 'Goodbye' }] });
   });
-  
+
+  it('Call createEntry() with a new key should create a new entry', async () => {
+    expect.assertions(3);
+    await expect(configService.createRepository({ repository })).resolves.toEqual({ repository });
+    await expect(configService.createEntry({ repository, key, value })).resolves.toEqual({});
+    return expect(configService.entries({ repository })).resolves.toEqual({ entries: [{ key, value }] });
+  });
+
+  it('Call updateEntry() with an existing key should update the relevant entry', async () => {
+    expect.assertions(4);
+    const newValue = { value: 'new' };
+    await expect(configService.createRepository({ repository })).resolves.toEqual({ repository });
+    await expect(configService.createEntry({ repository, key, value })).resolves.toEqual({});
+    await expect(configService.updateEntry({ repository, key, value: newValue })).resolves.toEqual({});
+    return expect(configService.entries({ repository })).resolves.toEqual({ entries: [{ key, value: newValue }] });
+  });
+
 });

--- a/tests/ConfigurationServiceLocalStorage/errors.test.ts
+++ b/tests/ConfigurationServiceLocalStorage/errors.test.ts
@@ -1,7 +1,6 @@
-import { ConfigurationService } from 'api/ConfigurationService';
 import { ConfigurationServiceLocalStorage } from 'provider/LocalStorage';
-import { messages } from '../../src/utils';
-import { runTestsRejectedError } from '../utils';
+import { messages } from '../../src';
+import { invalidValues, invalidValuesForString, runTestsRejectedError } from '../utils';
 
 const token = 'token';
 const repository = 'Adele';
@@ -72,6 +71,58 @@ describe('Test suite for the ConfigurationServiceLocalStorage', () => {
     configService.entries({ repository }).catch(
       error => expect(error).toEqual(new Error(`Configuration repository ${repository} not found`))
     );
+  });
+
+  describe.each(['createEntry', 'updateEntry'])('Errors while the creation or updating of the entry', (methodName: 'createEntry' | 'updateEntry') => {
+    test.each(invalidValues)(
+      `Call ${methodName} with request, that is not an object, is rejected with an error (%s)`,
+      (invalidRequest) => {
+        expect.assertions(1);
+        return expect(configService[methodName](invalidRequest))
+          .rejects.toEqual(new Error(messages.invalidRequest));
+      });
+
+    test.each(invalidValuesForString)(
+      `Call ${methodName} with invalid repository is rejected with an error (%s)`,
+      (invalidRepository) => {
+        expect.assertions(1);
+        return expect(configService[methodName]({ repository: invalidRepository, key, value }))
+          .rejects.toEqual(new Error(messages.invalidRepository));
+      });
+
+    test.each(invalidValuesForString)(
+      `Call ${methodName} with invalid key is rejected with an error (%s)`,
+      (invalidKey) => {
+        expect.assertions(1);
+        return expect(configService[methodName]({ repository, key: invalidKey, value }))
+          .rejects.toEqual(new Error(messages.invalidKey));
+      });
+
+    it(`Call ${methodName} with a non-existent repository is rejected with an error`, () => {
+      expect.assertions(1);
+      const wrongRepository = 'wrong';
+      return expect(configService[methodName]({ repository: wrongRepository, key, value }))
+        .rejects.toEqual(new Error(messages.repositoryDoesNotExist(wrongRepository)));
+    });
+
+    it('Call createEntry() for an existing entry should be rejected with an error', async () => {
+      expect.assertions(4);
+      await expect(configService.createRepository({ repository })).resolves.toEqual({ repository });
+      await expect(configService.createEntry({ repository, key, value })).resolves.toEqual({});
+      await expect(configService.createEntry({ repository, key, value: { value: 'new' } }))
+        .rejects.toEqual(new Error(messages.entryAlreadyExist(key)));
+      return expect(configService.entries({ repository }))
+        .resolves.toEqual({ entries: [{ key, value }] });
+    });
+
+    it('Call updateEntry() for a non-existing entry should be rejected with an error', async () => {
+      expect.assertions(3);
+      await expect(configService.createRepository({ repository })).resolves.toEqual({ repository });
+      await expect(configService.updateEntry({ repository, key, value }))
+        .rejects.toEqual(new Error(messages.entryDoesNotExist(key)));
+      return expect(configService.entries({ repository }))
+        .resolves.toEqual({ entries: [] });
+    });
   });
 
 });

--- a/tests/ConfigurationServiceLocalStorage/errors.test.ts
+++ b/tests/ConfigurationServiceLocalStorage/errors.test.ts
@@ -104,25 +104,25 @@ describe('Test suite for the ConfigurationServiceLocalStorage', () => {
       return expect(configService[methodName]({ repository: wrongRepository, key, value }))
         .rejects.toEqual(new Error(messages.repositoryDoesNotExist(wrongRepository)));
     });
+  });
 
-    it('Call createEntry() for an existing entry should be rejected with an error', async () => {
-      expect.assertions(4);
-      await expect(configService.createRepository({ repository })).resolves.toEqual({ repository });
-      await expect(configService.createEntry({ repository, key, value })).resolves.toEqual({});
-      await expect(configService.createEntry({ repository, key, value: { value: 'new' } }))
-        .rejects.toEqual(new Error(messages.entryAlreadyExist(key)));
-      return expect(configService.entries({ repository }))
-        .resolves.toEqual({ entries: [{ key, value }] });
-    });
+  it('Call createEntry() for an existing entry should be rejected with an error', async () => {
+    expect.assertions(4);
+    await expect(configService.createRepository({ repository })).resolves.toEqual({ repository });
+    await expect(configService.createEntry({ repository, key, value })).resolves.toEqual({});
+    await expect(configService.createEntry({ repository, key, value: { value: 'new' } }))
+      .rejects.toEqual(new Error(messages.entryAlreadyExist(key)));
+    return expect(configService.entries({ repository }))
+      .resolves.toEqual({ entries: [{ key, value }] });
+  });
 
-    it('Call updateEntry() for a non-existing entry should be rejected with an error', async () => {
-      expect.assertions(3);
-      await expect(configService.createRepository({ repository })).resolves.toEqual({ repository });
-      await expect(configService.updateEntry({ repository, key, value }))
-        .rejects.toEqual(new Error(messages.entryDoesNotExist(key)));
-      return expect(configService.entries({ repository }))
-        .resolves.toEqual({ entries: [] });
-    });
+  it('Call updateEntry() for a non-existing entry should be rejected with an error', async () => {
+    expect.assertions(3);
+    await expect(configService.createRepository({ repository })).resolves.toEqual({ repository });
+    await expect(configService.updateEntry({ repository, key, value }))
+      .rejects.toEqual(new Error(messages.entryDoesNotExist(key)));
+    return expect(configService.entries({ repository }))
+      .resolves.toEqual({ entries: [] });
   });
 
 });

--- a/tests/ConfigurationServiceScalecube/data.test.ts
+++ b/tests/ConfigurationServiceScalecube/data.test.ts
@@ -45,13 +45,13 @@ describe('Test suite for the ConfigurationServiceLocalScalecube', () => {
 
   it('Call createEntry() with a new key should create a new entry', () => {
     expect.assertions(1);
-    mockedCallback.mockResolvedValueOnce(Promise.resolve({ repository }));
+    mockedCallback.mockResolvedValueOnce({ repository });
     return expect(configService.createEntry({ repository, key, value })).resolves.toEqual({})
   });
 
   it('Call updateEntry() with an existing key should update the relevant entry', () => {
     expect.assertions(1);
-    mockedCallback.mockResolvedValueOnce(Promise.resolve({ repository }));
+    mockedCallback.mockResolvedValueOnce({ repository });
     return expect(configService.updateEntry({ repository, key, value })).resolves.toEqual({})
   });
 });

--- a/tests/ConfigurationServiceScalecube/data.test.ts
+++ b/tests/ConfigurationServiceScalecube/data.test.ts
@@ -42,4 +42,16 @@ describe('Test suite for the ConfigurationServiceLocalScalecube', () => {
     mockedCallback.mockResolvedValueOnce({repository});
     expect(await configService.save({repository, key, value})).toEqual({repository});
   });
+
+  it('Call createEntry() with a new key should create a new entry', () => {
+    expect.assertions(1);
+    mockedCallback.mockResolvedValueOnce(Promise.resolve({ repository }));
+    return expect(configService.createEntry({ repository, key, value })).resolves.toEqual({})
+  });
+
+  it('Call updateEntry() with an existing key should update the relevant entry', () => {
+    expect.assertions(1);
+    mockedCallback.mockResolvedValueOnce(Promise.resolve({ repository }));
+    return expect(configService.updateEntry({ repository, key, value })).resolves.toEqual({})
+  });
 });

--- a/tests/ConfigurationServiceScalecube/data.test.ts
+++ b/tests/ConfigurationServiceScalecube/data.test.ts
@@ -46,12 +46,12 @@ describe('Test suite for the ConfigurationServiceLocalScalecube', () => {
   it('Call createEntry() with a new key should create a new entry', () => {
     expect.assertions(1);
     mockedCallback.mockResolvedValueOnce({ repository });
-    return expect(configService.createEntry({ repository, key, value })).resolves.toEqual({})
+    return expect(configService.createEntry({ repository, key, value })).resolves.toEqual({});
   });
 
   it('Call updateEntry() with an existing key should update the relevant entry', () => {
     expect.assertions(1);
     mockedCallback.mockResolvedValueOnce({ repository });
-    return expect(configService.updateEntry({ repository, key, value })).resolves.toEqual({})
+    return expect(configService.updateEntry({ repository, key, value })).resolves.toEqual({});
   });
 });

--- a/tests/ConfigurationServiceScalecube/errors.test.ts
+++ b/tests/ConfigurationServiceScalecube/errors.test.ts
@@ -1,5 +1,5 @@
 import {AxiosDispatcher} from '@capsulajs/capsulajs-transport-providers';
-import {ConfigurationServiceScalecube} from '../../src/provider/Scalecube/ConfigurationServiceScalecube';
+import {ConfigurationServiceScalecube} from '../../src';
 import {messages} from '../../src';
 import {getRepositoryKeyNotFoundErrorMessage, getRepositoryNotFoundErrorMessage} from '../../src/utils';
 import { invalidValues, invalidValuesForString, runTestsRejectedError } from '../utils';

--- a/tests/ConfigurationServiceScalecube/errors.test.ts
+++ b/tests/ConfigurationServiceScalecube/errors.test.ts
@@ -83,70 +83,36 @@ describe('Errors tests for the ConfigurationServiceScalecube', () => {
     return expect(configService.createRepository({repository})).rejects.toEqual(exception);
   });
 
-  // CreateEntry
+  describe.each(['createEntry', 'updateEntry'])('Errors while the creation or updating of the entry', (methodName: 'createEntry' | 'updateEntry') => {
+    test.each(invalidValues)(
+      `Call ${methodName} with request, that is not an object, is rejected with an error (%s)`,
+      (invalidRequest) => {
+        expect.assertions(1);
+        return expect(configService[methodName](invalidRequest))
+          .rejects.toEqual(new Error(messages.invalidRequest));
+      });
 
-  test.each(invalidValues)(
-    'Call createEntry with request, that is not an object, is rejected with an error (%s)',
-    (invalidRequest) => {
+    test.each(invalidValuesForString)(
+      `Call ${methodName} with invalid repository is rejected with an error (%s)`,
+      (invalidRepository) => {
+        expect.assertions(1);
+        return expect(configService[methodName]({ repository: invalidRepository, key, value }))
+          .rejects.toEqual(new Error(messages.invalidRepository));
+      });
+
+    test.each(invalidValuesForString)(
+      `Call ${methodName} with invalid key is rejected with an error (%s)`,
+      (invalidKey) => {
+        expect.assertions(1);
+        return expect(configService[methodName]({ repository, key: invalidKey, value }))
+          .rejects.toEqual(new Error(messages.invalidKey));
+      });
+
+    it(`Call ${methodName} with a valid request and there is a server error - promise is rejected with an error`, () => {
       expect.assertions(1);
-      return expect(configService.createEntry(invalidRequest))
-        .rejects.toEqual(new Error(messages.invalidRequest));
+      const exception = { errorCode: 500, errorMessage: 'Server error' };
+      mockedCallback.mockRejectedValueOnce(exception);
+      return expect(configService[methodName]({ repository, key, value })).rejects.toEqual(exception);
     });
-
-  test.each(invalidValuesForString)(
-    'Call createEntry with invalid repository is rejected with an error (%s)',
-    (invalidRepository) => {
-      expect.assertions(1);
-      return expect(configService.createEntry({ repository: invalidRepository, key, value }))
-        .rejects.toEqual(new Error(messages.invalidRepository));
-    });
-
-  test.each(invalidValuesForString)(
-    'Call createEntry with invalid key is rejected with an error (%s)',
-    (invalidKey) => {
-      expect.assertions(1);
-      return expect(configService.createEntry({ repository, key: invalidKey, value }))
-        .rejects.toEqual(new Error(messages.invalidKey));
-    });
-
-  it('Call createEntry with a valid request and there is a server error - promise is rejected with an error', () => {
-    expect.assertions(1);
-    const exception = { errorCode: 500, errorMessage: 'The entry already exists' };
-    mockedCallback.mockRejectedValueOnce(exception);
-    return expect(configService.updateEntry({ repository, key, value })).rejects.toEqual(exception);
   });
-
-  // UpdateEntry
-
-  test.each(invalidValues)(
-    'Call updateEntry with request, that is not an object, is rejected with an error (%s)',
-    (invalidRequest) => {
-      expect.assertions(1);
-      return expect(configService.updateEntry(invalidRequest))
-        .rejects.toEqual(new Error(messages.invalidRequest));
-    });
-
-  test.each(invalidValuesForString)(
-    'Call updateEntry with invalid repository is rejected with an error (%s)',
-    (invalidRepository) => {
-      expect.assertions(1);
-      return expect(configService.updateEntry({ repository: invalidRepository, key, value }))
-        .rejects.toEqual(new Error(messages.invalidRepository));
-    });
-
-  test.each(invalidValuesForString)(
-    'Call updateEntry with invalid key is rejected with an error (%s)',
-    (invalidKey) => {
-      expect.assertions(1);
-      return expect(configService.updateEntry({ repository, key: invalidKey, value }))
-        .rejects.toEqual(new Error(messages.invalidKey));
-    });
-
-  it('Call updateEntry with a valid request and there is a server error - promise is rejected with an error', () => {
-    expect.assertions(1);
-    const exception = { errorCode: 500, errorMessage: 'The entry does not exists' };
-    mockedCallback.mockRejectedValueOnce(exception);
-    return expect(configService.updateEntry({ repository, key, value })).rejects.toEqual(exception);
-  });
-
 });

--- a/tests/features/ConfigurationServiceLocalStorage/data.feature
+++ b/tests/features/ConfigurationServiceLocalStorage/data.feature
@@ -37,3 +37,29 @@ Scenario: fetch() should return value by key
    And   an entry with key: X and value: Y is already saved
    When  user calls save method with key: X and value: Y and the name of this repository
    Then  the existing entry (key and the value) is rewritten and saved in the repository
+
+ Scenario:Call createEntry() with a new key should create a new entry
+   Given configurationServiceLocalStorage with createEntry method
+   And   an existing repository
+   And   an entry with key: X does not exist
+   When  user calls createEntry method with key: X and the following request
+        | <parameter> | <type>   |
+        | repository  | string   |
+        | value       | JsonNode |
+        | key         | string   |
+   And   key:X and value:Z
+   Then  the entry with key X is created with value Z
+   And   the promise that is returned from a method call resolves with an empty object
+
+  Scenario: Call updateEntry() with an existing key should update the relevant entry
+    Given configurationServiceLocalStorage with updateEntry method
+    And   an existing repository A
+    And   an entry with key: X and value: Y is already saved
+    When  user calls updateEntry method with key: X and the following request
+         | <parameter> | <type>   |
+         | repository  | string   |
+         | value       | JsonNode |
+         | key         | string   |
+    And   key:X and value:Z
+    Then  the entry with key X is updated with value Z
+    And   the promise that is returned from a method call resolves with an empty object

--- a/tests/features/ConfigurationServiceLocalStorage/errors.feature
+++ b/tests/features/ConfigurationServiceLocalStorage/errors.feature
@@ -60,8 +60,144 @@ Scenario: delete() without key should delete configuration repository
     When  user calls entries method with the name of the repository that was deleted
     Then  user receives an error 'Configuration repository is not found'
 
-Scenario: createRepository() providing an existing repository nname should return 'repositoryAlreadyExists' error
+Scenario: createRepository() providing an existing repository name should return 'repositoryAlreadyExists' error
   Given ConfigurationServiceLocalStorage with createRepository method
   And   an existing repository
   When  user calls createRepository method by providing the token and the existing name of repository
   Then  user receives an error that the repository already exists
+
+Scenario: Call createEntry() with request, that is not an object, is rejected with an error
+  Given  ConfigurationServiceLocalStorage with createEntry method
+  When   user calls createEntry method with following <request>
+          | <request> |
+          | ''        |
+          | ' '       |
+          | []        |
+          | ['test']  |
+          | null      |
+          | true      |
+          | false     |
+          | 0         |
+          | -1        |
+          | undefined |
+  Then   `invalidRequest` error message will be returned
+
+Scenario: Call createEntry() with invalid repository is rejected with an error
+  Given  ConfigurationServiceLocalStorage with createEntry method
+  And    an entry with key: X and value Z that does not exist
+  When   user calls createEntry method with key: X, value Z and with following <repository>
+          | <repository>  |
+          | ''        |
+          | ' '       |
+          | []        |
+          | ['test']  |
+          | null      |
+          | true      |
+          | false     |
+          | 0         |
+          | -1        |
+          | undefined |
+          | {}        |
+          | { test: 'test' } |
+  Then   `invalidRepository` error message will be returned
+
+Scenario: Call createEntry() with invalid key is rejected with an error
+  Given  ConfigurationServiceLocalStorage with createEntry method
+  And    an existing repository A
+  When   user calls createEntry method with repository: A, value: Z and with following <key>
+          | <key>     |
+          | ''        |
+          | ' '       |
+          | []        |
+          | ['test']  |
+          | null      |
+          | true      |
+          | false     |
+          | 0         |
+          | -1        |
+          | undefined |
+          | {}        |
+          | { test: 'test' } |
+  Then   `invalidKey` error message will be returned
+
+Scenario: Call createEntry() with a non-existent repository is rejected with an error
+  Given  ConfigurationServiceLocalStorage with createEntry method
+  And    non existing repository B
+  When   user calls createEntry method with repository: B, value: Z and with key: X
+  Then   `wrongRepository` error message will be returned
+
+Scenario: Call createEntry() for an existing entry should be rejected with an error
+  Given  ConfigurationServiceLocalStorage with createEntry method
+  And    an existing repository A
+  And    an entry with key: X and value: Y is already saved
+  When   user calls createEntry method with repository: A, value: Y and with key: X
+  Then   `entryAlreadyExist` error message will be returned
+
+Scenario: Call updateEntry() with request, that is not an object, is rejected with an error
+  Given  ConfigurationServiceLocalStorage with updateEntry method
+  When   user calls updateEntry method with following <request>
+          | <request> |
+          | ''        |
+          | ' '       |
+          | []        |
+          | ['test']  |
+          | null      |
+          | true      |
+          | false    |
+          | 0         |
+          | -1        |
+          | undefined |
+  Then   `invalidRequest` error message will be returned
+
+Scenario: Call updateEntry() with invalid repository is rejected with an error
+  Given  ConfigurationServiceLocalStorage with updateEntry method
+  And    an entry with key: X and value: Y is already saved
+  When   user calls updateEntry method with key: X, value Z and with following <repository>
+          | <repository>  |
+          | ''        |
+          | ' '       |
+          | []        |
+          | ['test']  |
+          | null      |
+          | true      |
+          | false     |
+          | 0         |
+          | -1        |
+          | undefined |
+          | {}        |
+          | { test: 'test' } |
+  Then   `invalidRepository` error message will be returned
+
+Scenario: Call updateEntry() with invalid key is rejected with an error
+  Given  ConfigurationServiceLocalStorage with updateEntry method
+  And    an existing repository A
+  When   user calls updateEntry method with repository:a, value:Z and with following <key>
+          | <key>     |
+          | ''        |
+          | ' '       |
+          | []        |
+          | ['test']  |
+          | null      |
+          | true      |
+          | false     |
+          | 0         |
+          | -1        |
+          | undefined |
+          | {}        |
+          | { test: 'test' } |
+  Then   `invalidKey` error message will be returned
+
+Scenario: Call updateEntry() with a non-existent repository is rejected with an error
+  Given  ConfigurationServiceLocalStorage with updateEntry method
+  And    non existing repository B
+  And    an entry with key: X and value: Y is already saved
+  When   user calls updateEntry method with repository: B, value:Z and with following key: X
+  Then   `wrongRepository` error message will be returned
+
+Scenario: Call updateEntry() for a non-existing entry should be rejected with an error
+  Given  ConfigurationServiceLocalStorage with updateEntry method
+  And    an existing repository A
+  And    an entry with key: X and value: Y doesn't exist
+  When   user calls updateEntry method with repository: A, value: Z and with key: X
+  Then   `entryDoesNotExist` error message will be returned
+  

--- a/tests/features/ConfigurationServiceScalecube/data.feature
+++ b/tests/features/ConfigurationServiceScalecube/data.feature
@@ -68,7 +68,7 @@ Feature: Data tests for the ConfigurationServiceScalecube
     Given configurationServiceScalecube with createEntry method
     And   an existing repository A
     And   an entry with key: X does not exist
-    When  user calls create method with key: X and the following request
+    When  user calls createEntry method with key: X and the following request
          | <parameter> | <type>   |
          | repository  | string   |
          | value       | JsonNode |
@@ -82,7 +82,7 @@ Feature: Data tests for the ConfigurationServiceScalecube
     Given configurationServiceScalecube with updateEntry method
     And   an existing repository A
     And   an entry with key: X and value: Y is already saved
-    When  user calls save method with key: X and the following request
+    When  user calls updateEntry method with key: X and the following request
          | <parameter> | <type>   |
          | repository  | string   |
          | value       | JsonNode |

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -47,3 +47,9 @@ export const mockFetchFile = (data: { type: 'resolve' | 'reject', content: any }
     }
   })
 };
+
+export const invalidValues = [' ', '', [], ['test'], null, true, false, 0, -1, undefined];
+
+export const invalidValuesForString = [...invalidValues, {}, { test: 'test' }];
+
+


### PR DESCRIPTION
https://github.com/capsulajs/configuration-service/issues/39

Release notes:
- save method is still preserved, but deprecated
- added createEntry and updateEntry public methods