### PR TITLE
Fix concurency bug when user use save() for localStorage provider simultaneously

### DIFF
--- a/src/provider/LocalStorage/ConfigurationServiceLocalStorage.ts
+++ b/src/provider/LocalStorage/ConfigurationServiceLocalStorage.ts
@@ -21,22 +21,6 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
     }
   }
 
-  private UNSAFE_getRepository(repository: string) {
-    const rawString = localStorage.getItem(`${this.token}.${repository}`);
-
-    if (!rawString) {
-      return Promise.reject(
-        new Error(messages.repositoryDoesNotExist(repository))
-      );
-    }
-
-    try {
-      return Promise.resolve(JSON.parse(rawString));
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  }
-
   private getRepository(repository: string) {
     const rawString = localStorage.getItem(`${this.token}.${repository}`);
     if (!rawString) {

--- a/src/provider/LocalStorage/ConfigurationServiceLocalStorage.ts
+++ b/src/provider/LocalStorage/ConfigurationServiceLocalStorage.ts
@@ -92,22 +92,22 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
     return { entries: Object.keys(repository).map(key => ({ key, value: repository[key] }))};
   };
 
-  fetch(request: FetchRequest): Promise<FetchResponse> {
+  async fetch(request: FetchRequest): Promise<FetchResponse> {
     if (repositoryRequestValidator(request)) {
-      return Promise.reject(new Error(messages.repositoryNotProvided));
+      throw new Error(messages.repositoryNotProvided);
     }
 
     if (repositoryKeyRequestValidator(request)) {
-      return Promise.reject(new Error(messages.repositoryKeyNotProvided));
+      throw new Error(messages.repositoryKeyNotProvided);
     }
 
-    return new Promise((resolve, reject) => {
-      this.UNSAFE_getRepository(request.repository).then(repository =>
-        Object.keys(repository).indexOf(request.key) >= 0
-          ? resolve({ key: request.key, value: repository[request.key] })
-          : reject(new Error(`Configuration repository key ${request.key} not found`))
-      ).catch(reject);
-    });
+    const repository = this.getRepository(request.repository)
+
+    if (Object.keys(repository).indexOf(request.key) >= 0) {
+      return { key: request.key, value: repository[request.key] };
+    }
+
+    throw new Error(`Configuration repository key ${request.key} not found`);
   }
 
   async save(request: SaveRequest): Promise<SaveResponse> {

--- a/src/provider/LocalStorage/ConfigurationServiceLocalStorage.ts
+++ b/src/provider/LocalStorage/ConfigurationServiceLocalStorage.ts
@@ -64,27 +64,23 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
     throw new Error(messages.repositoryAlreadyExists);
   }
 
-  delete(request: DeleteRequest): Promise<DeleteResponse> {
+  async delete(request: DeleteRequest): Promise<DeleteResponse> {
     if (repositoryRequestValidator(request)) {
-      return Promise.reject(new Error(messages.repositoryNotProvided));
+      throw new Error(messages.repositoryNotProvided);
     }
 
-    return new Promise((resolve, reject) => {
-      this.UNSAFE_getRepository(request.repository).then((repository) => {
-        if (request.key) {
-          if (!repository.hasOwnProperty(request.key)) {
-            reject(new Error(`Configuration repository key ${request.key} not found`));
-          }
+    const repository = this.getRepository(request.repository);
+    if (request.key && !repository.hasOwnProperty(request.key)) {
+        throw new Error(`Configuration repository key ${request.key} not found`);
+    }
 
-          const { [request.key]: value, ...rest } = repository;
-          this.setRepository(request.repository, rest);
-        } else {
-          localStorage.removeItem(`${this.token}.${request.repository}`);
-        }
-
-        resolve({});
-      }).catch(reject);
-    });
+    if (request.key) {
+      const { [request.key]: value, ...rest } = repository;
+      this.setRepository(request.repository, rest);
+    } else {
+      localStorage.removeItem(`${this.token}.${request.repository}`);
+    }
+    return {};
   }
 
   async entries(request: EntriesRequest): Promise<EntriesResponse<T>> {

--- a/src/provider/LocalStorage/ConfigurationServiceLocalStorage.ts
+++ b/src/provider/LocalStorage/ConfigurationServiceLocalStorage.ts
@@ -21,7 +21,7 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
     }
   }
 
-  private getRepository(repository: string) {
+  private UNSAFE_getRepository(repository: string) {
     const rawString = localStorage.getItem(`${this.token}.${repository}`);
 
     if (!rawString) {
@@ -70,7 +70,7 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
     }
 
     return new Promise((resolve, reject) => {
-      this.getRepository(request.repository).then((repository) => {
+      this.UNSAFE_getRepository(request.repository).then((repository) => {
         if (request.key) {
           if (!repository.hasOwnProperty(request.key)) {
             reject(new Error(`Configuration repository key ${request.key} not found`));
@@ -106,7 +106,7 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
     }
 
     return new Promise((resolve, reject) => {
-      this.getRepository(request.repository).then(repository =>
+      this.UNSAFE_getRepository(request.repository).then(repository =>
         Object.keys(repository).indexOf(request.key) >= 0
           ? resolve({ key: request.key, value: repository[request.key] })
           : reject(new Error(`Configuration repository key ${request.key} not found`))
@@ -146,7 +146,7 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
       return Promise.reject(error);
     }
 
-    return this.getRepository(request.repository)
+    return this.UNSAFE_getRepository(request.repository)
       .then(repositoryData => {
         if (mode === 'create' && repositoryData.hasOwnProperty(request.key)) {
           throw new Error(messages.entryAlreadyExist(request.key));

--- a/src/provider/LocalStorage/ConfigurationServiceLocalStorage.ts
+++ b/src/provider/LocalStorage/ConfigurationServiceLocalStorage.ts
@@ -37,7 +37,7 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
     }
   }
 
-  private getRepositorySync(repository: string) {
+  private getRepository(repository: string) {
     const rawString = localStorage.getItem(`${this.token}.${repository}`);
     if (!rawString) {
       throw new Error(messages.repositoryDoesNotExist(repository));
@@ -56,7 +56,7 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
     }
 
     try {
-      this.getRepositorySync(request.repository);
+      this.getRepository(request.repository);
     } catch {
       this.setRepository(request.repository, {});
       return { repository: request.repository };
@@ -92,7 +92,7 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
       return Promise.reject(new Error(messages.repositoryNotProvided));
     }
 
-    const repository = this.getRepositorySync(request.repository);
+    const repository = this.getRepository(request.repository);
     return { entries: Object.keys(repository).map(key => ({ key, value: repository[key] }))};
   };
 
@@ -123,9 +123,9 @@ export class ConfigurationServiceLocalStorage<T=any> implements ConfigurationSer
       throw new Error(messages.repositoryKeyNotProvided);
     }
 
-    const repositoryData = this.getRepositorySync(request.repository);
+    const repositoryData = this.getRepository(request.repository);
     this.setRepository(request.repository, {
-      ...this.getRepositorySync(request.repository),
+      ...this.getRepository(request.repository),
       [request.key]: request.value
     });
     return {};

--- a/tests/ConfigurationServiceLocalStorage/data.test.ts
+++ b/tests/ConfigurationServiceLocalStorage/data.test.ts
@@ -5,6 +5,7 @@ const repository = 'Adele';
 const key = 'Hello';
 const value = 'It\'s me';
 const configService = new ConfigurationServiceLocalStorage(token);
+const arrayFixture = [{ key: '1', value: 1 }, { key: '2', value: 2 }, { key: '3', value: 3 }];
 
 describe('Test suite for the ConfigurationServiceLocalStorage', () => {
   beforeEach(localStorage.clear);
@@ -57,6 +58,18 @@ describe('Test suite for the ConfigurationServiceLocalStorage', () => {
     expect(await configService.entries({ repository })).toEqual({ entries: [{ key, value }] });
     expect(await configService.save({ repository, key, value: 'Goodbye' })).toEqual({});
     expect(await configService.entries({ repository })).toEqual({ entries: [{ key, value: 'Goodbye' }] });
+  });
+
+  it('save() concurency check', async () => {
+    expect.assertions(3);
+    expect(await configService.createRepository({ repository })).toEqual({ repository });
+    expect(await Promise.all(arrayFixture.map(({ key, value }, id) => configService.save({
+      repository,
+      key,
+      value,
+    })))).toEqual([{}, {}, {}]);
+
+    expect(await configService.entries({ repository })).toEqual({ entries: arrayFixture });
   });
 
   it('Call createEntry() with a new key should create a new entry', async () => {


### PR DESCRIPTION
## Plan is
1. Add test to show the problem
2. fix the problem
3. Remove redundant use of promises

## Workflow is:
1. Added test "'save() concurency check'" which reproduce the bug before I have started fixing the problem.
2. Found problem in private async method "getRepository"
3. Created new private method "getRepositorySync"
4. Rewrite all methods to use getRepositorySync
5. remove method getRepository and rename getRepositorySync to getRepository
